### PR TITLE
feat: export error meta info for option resolving

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@
 
 export { parse } from './parse.js'
 export { parseArgs } from './parser.js'
-export { resolveArgs } from './resolver.js'
+export { OptionResolveError, resolveArgs } from './resolver.js'
 
 export type { ParsedArgs, ParseOptions } from './parse'
 export type { ArgToken, ParserOptions } from './parser'

--- a/src/resolver.test.ts
+++ b/src/resolver.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 import { parseArgs } from './parser'
-import { resolveArgs } from './resolver'
+import { OptionResolveError, resolveArgs } from './resolver'
 
 import type { ArgOptions } from './resolver'
 
@@ -49,6 +49,8 @@ describe('resolveArgs', () => {
     const { error } = resolveArgs(options, tokens)
     expect(error?.errors.length).toBe(1)
     expect((error?.errors[0] as Error).message).toEqual("Option '--host' or '-o' is required")
+    expect((error?.errors[0] as OptionResolveError).name).toEqual('host')
+    expect((error?.errors[0] as OptionResolveError).schema.type).toEqual('string')
   })
 
   test('missing defaultable option', () => {
@@ -67,9 +69,11 @@ describe('resolveArgs', () => {
     const tokens = parseArgs(args)
     const { error } = resolveArgs(options, tokens)
     expect(error?.errors.length).toBe(1)
-    expect((error?.errors[0] as Error).message).toEqual(
+    expect((error?.errors[0] as OptionResolveError).message).toEqual(
       "Option '--port' or '-p' should be 'number'"
     )
+    expect((error?.errors[0] as OptionResolveError).name).toEqual('port')
+    expect((error?.errors[0] as OptionResolveError).schema.type).toEqual('number')
   })
 
   test('multiple errors', () => {
@@ -80,7 +84,11 @@ describe('resolveArgs', () => {
     expect((error?.errors[0] as Error).message).toEqual(
       "Option '--port' or '-p' should be 'number'"
     )
-    expect((error?.errors[1] as Error).message).toEqual("Option '--host' or '-o' is required")
+    expect((error?.errors[1] as OptionResolveError).message).toEqual(
+      "Option '--host' or '-o' is required"
+    )
+    expect((error?.errors[1] as OptionResolveError).name).toEqual('host')
+    expect((error?.errors[1] as OptionResolveError).schema.type).toEqual('string')
   })
 
   test('missing positionals', () => {

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -268,10 +268,22 @@ export function resolveArgs<T extends ArgOptions>(
   return { values, positionals, error: errors.length > 0 ? new AggregateError(errors) : undefined }
 }
 
-function createRequireError(option: string, schema: ArgOptionSchema): Error {
-  return new Error(
-    `Option '--${option}' ${schema.short ? `or '-${schema.short}' ` : ''}is required`
+function createRequireError(option: string, schema: ArgOptionSchema): OptionResolveError {
+  return new OptionResolveError(
+    `Option '--${option}' ${schema.short ? `or '-${schema.short}' ` : ''}is required`,
+    option,
+    schema
   )
+}
+
+export class OptionResolveError extends Error {
+  name: string
+  schema: ArgOptionSchema
+  constructor(message: string, name: string, schema: ArgOptionSchema) {
+    super(message)
+    this.name = name
+    this.schema = schema
+  }
 }
 
 function validateRequire(
@@ -312,8 +324,10 @@ function isNumeric(str: string): boolean {
 }
 
 function createTypeError(option: string, schema: ArgOptionSchema): TypeError {
-  return new TypeError(
-    `Option '--${option}' ${schema.short ? `or '-${schema.short}' ` : ''}should be '${schema.type}'`
+  return new OptionResolveError(
+    `Option '--${option}' ${schema.short ? `or '-${schema.short}' ` : ''}should be '${schema.type}'`,
+    option,
+    schema
   )
 }
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/args-tokens/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

AggregateError will have multiple Errors, If the current `resolveArgs` fails to resolve options. 
However, there is no information such as the schema of the corresponding option, only the message.
This makes it difficult to localize the error messages.

To solve this, we will extend Error to allow use of the optioin name and its schema.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
