### PR TITLE
feat: support rest arguments

### DIFF
--- a/src/parse.test.ts
+++ b/src/parse.test.ts
@@ -40,9 +40,14 @@ test('parse', () => {
     '-h',
     '--version',
     'bar',
-    'baz'
+    'baz',
+    '--',
+    '--help',
+    '--version',
+    '--port',
+    '8080'
   ]
-  const { values, positionals, tokens } = parse(args, { options })
+  const { values, positionals, rest, tokens } = parse(args, { options })
   expect(values).toEqual({
     port: 9131,
     host: 'example.com',
@@ -51,5 +56,6 @@ test('parse', () => {
     version: true
   })
   expect(positionals).toEqual(['dev', 'foo', 'bar', 'baz'])
+  expect(rest).toEqual(['--help', '--version', '--port', '8080'])
   expect(tokens).toEqual(parseArgs(args))
 })

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -32,6 +32,10 @@ export type ParsedArgs<T extends ArgOptions> = {
    */
   positionals: string[]
   /**
+   * Rest arguments, same as `rest` in {@link resolveArgs}.
+   */
+  rest: string[]
+  /**
    * Validation errors, same as `errors` in {@link resolveArgs}.
    */
   error: AggregateError | undefined

--- a/src/resolver.test.ts
+++ b/src/resolver.test.ts
@@ -33,13 +33,14 @@ describe('resolveArgs', () => {
   test('basic', () => {
     const args = ['dev', '--port=9131', '--host=example.com', '--help']
     const tokens = parseArgs(args)
-    const { values, positionals, error } = resolveArgs(options, tokens)
+    const { values, positionals, rest, error } = resolveArgs(options, tokens)
     expect(values).toEqual({
       port: 9131,
       host: 'example.com',
       help: true
     })
     expect(positionals).toEqual(['dev'])
+    expect(rest).toEqual([])
     expect(error).toBeUndefined()
   })
 
@@ -57,12 +58,13 @@ describe('resolveArgs', () => {
   test('missing defaultable option', () => {
     const args = ['dev', '--host=example.com']
     const tokens = parseArgs(args)
-    const { values, positionals } = resolveArgs(options, tokens)
+    const { values, positionals, rest } = resolveArgs(options, tokens)
     expect(values).toEqual({
       port: 8080,
       host: 'example.com'
     })
     expect(positionals).toEqual(['dev'])
+    expect(rest).toEqual([])
   })
 
   test('invalid value', () => {
@@ -118,52 +120,56 @@ describe('resolveArgs', () => {
   test('long options value captured from positionals', () => {
     const args = ['dev', '--port', '9131', '--host', 'example.com', 'bar']
     const tokens = parseArgs(args)
-    const { values, positionals } = resolveArgs(options, tokens)
+    const { values, positionals, rest } = resolveArgs(options, tokens)
     expect(values).toEqual({
       port: 9131,
       host: 'example.com'
     })
     expect(positionals).toEqual(['dev', 'bar'])
+    expect(rest).toEqual([])
   })
 
   test('short options value specified with equals', () => {
     const args = ['dev', '-p=9131', '-o=example.com', '-h']
     const tokens = parseArgs(args)
-    const { values, positionals, error } = resolveArgs(options, tokens)
+    const { values, positionals, rest, error } = resolveArgs(options, tokens)
     expect(values).toEqual({
       port: 9131,
       host: 'example.com',
       help: true
     })
     expect(positionals).toEqual(['dev'])
+    expect(rest).toEqual([])
     expect(error).toBeUndefined()
   })
 
   test('short options value specified with concatenation', () => {
     const args = ['dev', '-p9131', '-oexample.com']
     const tokens = parseArgs(args)
-    const { values, positionals, error } = resolveArgs(options, tokens)
+    const { values, positionals, rest, error } = resolveArgs(options, tokens)
     expect(values).toEqual({
       port: 9131,
       host: 'example.com'
     })
     expect(positionals).toEqual(['dev'])
+    expect(rest).toEqual([])
     expect(error).toBeUndefined()
   })
 
   test('short options value captured from positionals', () => {
     const args = ['dev', '-p', '9131', '-o', 'example.com', 'bar']
     const tokens = parseArgs(args)
-    const { values, positionals, error } = resolveArgs(options, tokens)
+    const { values, positionals, rest, error } = resolveArgs(options, tokens)
     expect(values).toEqual({
       port: 9131,
       host: 'example.com'
     })
     expect(positionals).toEqual(['dev', 'bar'])
+    expect(rest).toEqual([])
     expect(error).toBeUndefined()
   })
 
-  test('complex options', () => {
+  test.only('complex options', () => {
     const args = [
       'dev',
       '-p9131',
@@ -174,10 +180,14 @@ describe('resolveArgs', () => {
       '-h',
       '--version',
       'bar',
-      'baz'
+      'baz',
+      '--',
+      '--foo',
+      '--bar',
+      'test'
     ]
     const tokens = parseArgs(args)
-    const { values, positionals, error } = resolveArgs(options, tokens)
+    const { values, positionals, rest, error } = resolveArgs(options, tokens)
     expect(values).toEqual({
       port: 9131,
       host: 'example.com',
@@ -186,13 +196,14 @@ describe('resolveArgs', () => {
       version: true
     })
     expect(positionals).toEqual(['dev', 'foo', 'bar', 'baz'])
+    expect(rest).toEqual(['--foo', '--bar', 'test'])
     expect(error).toBeUndefined()
   })
 
   test('sanitize options', () => {
     const args = ['dev', '--__proto__', '{ "polluted": 1 }']
     const tokens = parseArgs(args)
-    const { values, positionals, error } = resolveArgs(
+    const { values, positionals, rest, error } = resolveArgs(
       {
         __proto__: {
           type: 'string'
@@ -208,6 +219,7 @@ describe('resolveArgs', () => {
       foo: 'foo'
     })
     expect(positionals).toEqual(['dev'])
+    expect(rest).toEqual([])
     expect(error).toBeUndefined()
   })
 })
@@ -216,7 +228,7 @@ describe('option group', () => {
   test('basic', () => {
     const args = ['dev', '-dsV']
     const tokens = parseArgs(args)
-    const { values, positionals } = resolveArgs(
+    const { values, positionals, rest } = resolveArgs(
       {
         debug: {
           type: 'boolean',
@@ -235,6 +247,7 @@ describe('option group', () => {
       { optionGrouping: true }
     )
     expect(positionals).toEqual(['dev'])
+    expect(rest).toEqual([])
     expect(values).toEqual({
       debug: true,
       silent: true,
@@ -245,7 +258,7 @@ describe('option group', () => {
   test('mix option grouping and long option', () => {
     const args = ['dev', '-ds', '--host', 'example.com', '-Vm', 'foo', 'bar']
     const tokens = parseArgs(args)
-    const { values, positionals } = resolveArgs(
+    const { values, positionals, rest } = resolveArgs(
       {
         debug: {
           type: 'boolean',
@@ -272,6 +285,7 @@ describe('option group', () => {
       { optionGrouping: true }
     )
     expect(positionals).toEqual(['dev', 'foo', 'bar'])
+    expect(rest).toEqual([])
     expect(values).toEqual({
       debug: true,
       silent: true,
@@ -286,7 +300,7 @@ describe('enum option', () => {
   test('basic', () => {
     const args = ['dev', '--log=debug']
     const tokens = parseArgs(args)
-    const { values, positionals } = resolveArgs(
+    const { values, positionals, rest } = resolveArgs(
       {
         log: {
           type: 'enum',
@@ -300,6 +314,7 @@ describe('enum option', () => {
       log: 'debug'
     })
     expect(positionals).toEqual(['dev'])
+    expect(rest).toEqual([])
   })
 
   test('invalid value', () => {

--- a/src/resolver.test.ts
+++ b/src/resolver.test.ts
@@ -169,7 +169,7 @@ describe('resolveArgs', () => {
     expect(error).toBeUndefined()
   })
 
-  test.only('complex options', () => {
+  test('complex options', () => {
     const args = [
       'dev',
       '-p9131',
@@ -363,7 +363,7 @@ describe('enum option', () => {
   test('missing', () => {
     const args = ['dev', '--', 'bar']
     const tokens = parseArgs(args)
-    const { error, values, positionals } = resolveArgs(
+    const { error, values, positionals, rest } = resolveArgs(
       {
         log: {
           type: 'enum',
@@ -375,7 +375,8 @@ describe('enum option', () => {
     )
     expect(error).toBeUndefined()
     expect(values).toEqual({})
-    expect(positionals).toEqual(['dev', 'bar'])
+    expect(positionals).toEqual(['dev'])
+    expect(rest).toEqual(['bar'])
   })
 
   test('default', () => {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/args-tokens/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

The Utility Conventions specify that when the `--` terminate option is specified, subsequent arguments are not parsed and are passed to other utilities as-is.

- guidline 10
https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap12.html

args-tokens provides convenient rest arguments to support this.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

resolve #49 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
