### PR TITLE
feat!: support negatable per option

### DIFF
--- a/src/parse.test.ts
+++ b/src/parse.test.ts
@@ -23,7 +23,8 @@ const options = {
     short: 'm'
   },
   silent: {
-    type: 'boolean'
+    type: 'boolean',
+    negatable: true
   },
   host: {
     type: 'string',
@@ -51,7 +52,7 @@ test('parse', () => {
     '--port',
     '8080'
   ]
-  const { values, positionals, rest, tokens } = parse(args, { options, allowNegative: true })
+  const { values, positionals, rest, tokens } = parse(args, { options })
   expect(values).toEqual({
     port: 9131,
     host: 'example.com',

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -75,11 +75,11 @@ export function parse<O extends ArgOptions>(
   args: string[],
   options: ParseOptions<O> = {}
 ): ParsedArgs<O> {
-  const { options: argOptions, allowCompatible = false, allowNegative = false } = options
+  const { options: argOptions, allowCompatible = false } = options
   const tokens = parseArgs(args, { allowCompatible })
   return Object.assign(
     Object.create(null),
-    resolveArgs<O>((argOptions as O) || DEFAULT_OPTIONS, tokens, { allowNegative }),
+    resolveArgs<O>((argOptions as O) || DEFAULT_OPTIONS, tokens),
     { tokens }
   )
 }

--- a/src/resolver.test.ts
+++ b/src/resolver.test.ts
@@ -13,6 +13,11 @@ const options = {
     type: 'boolean',
     short: 'v'
   },
+  silent: {
+    type: 'boolean',
+    short: 's',
+    negatable: true
+  },
   port: {
     type: 'number',
     short: 'p',
@@ -130,13 +135,13 @@ describe('resolveArgs', () => {
   })
 
   test('long options boolean negative value', () => {
-    const args = ['dev', '--no-help', '--version']
+    const args = ['dev', '--version', '--no-silent']
     const tokens = parseArgs(args)
-    const { values, positionals, rest } = resolveArgs(options, tokens, { allowNegative: true })
+    const { values, positionals, rest } = resolveArgs(options, tokens)
     expect(values).toEqual({
       port: 8080,
-      help: false,
-      version: true
+      version: true,
+      silent: false
     })
     expect(positionals).toEqual(['dev'])
     expect(rest).toEqual([])


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/args-tokens/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

In #70, negatable option for `boolean` type option was introduced in args-token with `allowNegative`.
But, it has been forced for all options.
`negatable` per `boolean` type option will be able to enable flexible.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
