### PR TITLE
breaking: change resolveArgs grouping option name

### DIFF
--- a/src/resolver.test.ts
+++ b/src/resolver.test.ts
@@ -264,7 +264,7 @@ describe('option group', () => {
         }
       },
       tokens,
-      { optionGrouping: true }
+      { shortGrouping: true }
     )
     expect(positionals).toEqual(['dev'])
     expect(rest).toEqual([])
@@ -302,7 +302,7 @@ describe('option group', () => {
         }
       },
       tokens,
-      { optionGrouping: true }
+      { shortGrouping: true }
     )
     expect(positionals).toEqual(['dev', 'foo', 'bar'])
     expect(rest).toEqual([])

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -26,7 +26,7 @@ export interface ArgSchema {
    */
   type: 'string' | 'boolean' | 'number' | 'enum' | 'positional'
   /**
-   * A single character alias for the option.
+   * A single character alias for the argument.
    */
   short?: string
   /**
@@ -123,11 +123,11 @@ export type FilterArgs<
  */
 export interface ResolveArgs {
   /**
-   * Whether to group short options.
+   * Whether to group short arguments.
    * @default false
    * @see guideline 5 in https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap12.html
    */
-  optionGrouping?: boolean
+  shortGrouping?: boolean
   /**
    * Skip positional arguments index.
    * @default -1
@@ -147,7 +147,7 @@ const SKIP_POSITIONAL_DEFAULT = -1
 export function resolveArgs<A extends Args>(
   args: A,
   tokens: ArgToken[],
-  { optionGrouping = false, skipPositional = SKIP_POSITIONAL_DEFAULT }: ResolveArgs = {}
+  { shortGrouping = false, skipPositional = SKIP_POSITIONAL_DEFAULT }: ResolveArgs = {}
 ): {
   values: ArgValues<A>
   positionals: string[]
@@ -244,7 +244,7 @@ export function resolveArgs<A extends Args>(
         } else if (isShortOption(token.rawName)) {
           if (currentShortOption) {
             if (currentShortOption.index === token.index) {
-              if (optionGrouping) {
+              if (shortGrouping) {
                 currentShortOption.value = token.value
                 optionTokens.push({ ...currentShortOption })
                 currentShortOption = { ...token }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/args-tokens/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

To make `resolveArgs`’s `optionGrouping` easier to understand, we will change it to `shortGrouping`.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated terminology in documentation and settings from "option grouping" to "short grouping" for improved clarity.
- **Tests**
	- Adjusted test cases to use the new "short grouping" configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->