### PR TITLE
fix: cannot resolve type for positional type

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,7 +14,7 @@
     "*.json": "jsonc"
   },
   "typescript.referencesCodeLens.enabled": true,
-  "typescript.experimental.useTsgo": false,
+  "typescript.experimental.useTsgo": true,
   "typescript.tsdk": "node_modules/typescript/lib",
   "deno.enable": false
 }

--- a/src/resolver.test-d.ts
+++ b/src/resolver.test-d.ts
@@ -80,6 +80,14 @@ test('ExtractOptionValue', () => {
     }>
   >().toEqualTypeOf<('a' | 'b' | 'c')[]>()
 
+  // positional type
+  expectTypeOf<
+    ExtractOptionValue<{
+      type: 'positional'
+      short: 's'
+    }>
+  >().toEqualTypeOf<string>()
+
   // custom type
   expectTypeOf<
     ExtractOptionValue<{
@@ -122,6 +130,7 @@ test('FilterArgs', () => {
       'type'
     >
   >().toEqualTypeOf<{ help: true }>()
+
   expectTypeOf<
     FilterArgs<
       {
@@ -134,6 +143,18 @@ test('FilterArgs', () => {
       'short'
     >
   >().toEqualTypeOf<{ help: true }>()
+
+  expectTypeOf<
+    FilterArgs<
+      {
+        order: {
+          type: 'positional'
+        }
+      },
+      { order: string },
+      'type'
+    >
+  >().toEqualTypeOf<{ order: string }>()
 
   expectTypeOf<
     FilterArgs<
@@ -204,6 +225,19 @@ test('ResolveArgValues', () => {
       { log: 'debug' }
     >
   >().toEqualTypeOf<{ log?: 'debug' | undefined }>()
+
+  // positional
+  expectTypeOf<
+    ResolveArgValues<
+      {
+        order: {
+          type: 'positional'
+          short: 'o'
+        }
+      },
+      { order: string }
+    >
+  >().toEqualTypeOf<{ order: string }>()
 })
 
 test('ArgValues', () => {
@@ -236,6 +270,10 @@ test('ArgValues', () => {
       short: 'l'
       choices: ['debug', 'info', 'warn', 'error']
     }
+    order: {
+      type: 'positional'
+      short: 'o'
+    }
     csv: {
       type: 'custom'
       parse: (value: string) => string[]
@@ -249,6 +287,7 @@ test('ArgValues', () => {
     host: string
     define?: string[]
     log?: 'debug' | 'info' | 'warn' | 'error'
+    order: string
     csv?: string[]
   }>()
 })

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -123,7 +123,8 @@ type ResolveOptionValue<A extends ArgSchema, T> = A['multiple'] extends true ? T
 export type ResolveArgValues<A extends Args, V extends Record<keyof A, unknown>> = {
   -readonly [Arg in keyof A]?: V[Arg]
 } & FilterArgs<A, V, 'default'> &
-  FilterArgs<A, V, 'required'> extends infer P
+  FilterArgs<A, V, 'required'> &
+  FilterPositionalArgs<A, V> extends infer P
   ? { [K in keyof P]: P[K] }
   : never
 
@@ -137,6 +138,13 @@ export type FilterArgs<
 > = {
   // eslint-disable-next-line @typescript-eslint/no-empty-object-type
   [Arg in keyof A as A[Arg][K] extends {} ? Arg : never]: V[Arg]
+}
+
+/**
+ * @internal
+ */
+export type FilterPositionalArgs<A extends Args, V extends Record<keyof A, unknown>> = {
+  [Arg in keyof A as A[Arg]['type'] extends 'positional' ? Arg : never]: V[Arg]
 }
 
 /**


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/args-tokens/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

resolve #105

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved support for positional arguments in argument parsing, ensuring they are now properly recognized and resolved as string values.

- **Tests**
  - Added comprehensive tests to validate correct handling and type inference for positional arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->