### PR TITLE
fix: export ‎`ArgExplicitlyProvided` type and remove readonly modifier

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,4 +14,11 @@ export { ArgResolveError, resolveArgs } from './resolver.ts'
 
 export type { ParsedArgs, ParseOptions } from './parse.ts'
 export type { ArgToken, ParserOptions } from './parser.ts'
-export type { ArgResolveErrorType, Args, ArgSchema, ArgValues, ResolveArgs } from './resolver.ts'
+export type {
+  ArgExplicitlyProvided,
+  ArgResolveErrorType,
+  Args,
+  ArgSchema,
+  ArgValues,
+  ResolveArgs
+} from './resolver.ts'

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -7,7 +7,7 @@ import { parseArgs } from './parser.ts'
 import { resolveArgs } from './resolver.ts'
 
 import type { ArgToken, ParserOptions } from './parser.ts'
-import type { Args, ArgValues, ResolveArgs, ExplicitlyProvided } from './resolver.ts'
+import type { ArgExplicitlyProvided, Args, ArgValues, ResolveArgs } from './resolver.ts'
 
 /**
  * Parse options for {@link parse} function.
@@ -47,7 +47,7 @@ export type ParsedArgs<A extends Args> = {
    * Explicit provision status, same as `explicit` in {@link resolveArgs}.
    * Indicates which arguments were explicitly provided vs using default values.
    */
-  explicit: ExplicitlyProvided<A>
+  explicit: ArgExplicitlyProvided<A>
 }
 
 const DEFAULT_OPTIONS = {

--- a/src/resolver.test-d.ts
+++ b/src/resolver.test-d.ts
@@ -298,7 +298,7 @@ test('ArgValues', () => {
   }>()
 })
 
-test('ExplicitlyProvided', () => {
+test('ArgExplicitlyProvided', () => {
   type Args = {
     name: {
       type: 'string'

--- a/src/resolver.test-d.ts
+++ b/src/resolver.test-d.ts
@@ -3,11 +3,11 @@ import { expectTypeOf, test } from 'vitest'
 import { z } from 'zod/v4-mini'
 
 import type {
+  ArgExplicitlyProvided,
   ArgValues,
   ExtractOptionValue,
   FilterArgs,
-  ResolveArgValues,
-  ExplicitlyProvided
+  ResolveArgValues
 } from './resolver.ts'
 
 test('ExtractOptionValue', () => {
@@ -325,7 +325,7 @@ test('ExplicitlyProvided', () => {
     }
   }
 
-  expectTypeOf<ExplicitlyProvided<Args>>().toEqualTypeOf<
+  expectTypeOf<ArgExplicitlyProvided<Args>>().toEqualTypeOf<
     Readonly<{
       name: boolean
       age: boolean

--- a/src/resolver.test-d.ts
+++ b/src/resolver.test-d.ts
@@ -325,15 +325,13 @@ test('ExplicitlyProvided', () => {
     }
   }
 
-  expectTypeOf<ArgExplicitlyProvided<Args>>().toEqualTypeOf<
-    Readonly<{
-      name: boolean
-      age: boolean
-      verbose: boolean
-      regularOption: boolean
-      custom: boolean
-    }>
-  >()
+  expectTypeOf<ArgExplicitlyProvided<Args>>().toEqualTypeOf<{
+    name: boolean
+    age: boolean
+    verbose: boolean
+    regularOption: boolean
+    custom: boolean
+  }>()
 })
 
 /* eslint-enable @typescript-eslint/no-empty-object-type */

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -177,7 +177,7 @@ const SKIP_POSITIONAL_DEFAULT = -1
  * Each property indicates whether the corresponding argument was explicitly
  * provided (true) or is using a default value or not provided (false).
  */
-export type ExplicitlyProvided<A extends Args> = {
+export type ArgExplicitlyProvided<A extends Args> = {
   readonly [K in keyof A]: boolean
 }
 
@@ -223,7 +223,7 @@ export function resolveArgs<A extends Args>(
   positionals: string[]
   rest: string[]
   error: AggregateError | undefined
-  explicit: ExplicitlyProvided<A>
+  explicit: ArgExplicitlyProvided<A>
 } {
   const skipPositionalIndex =
     typeof skipPositional === 'number'
@@ -368,7 +368,7 @@ export function resolveArgs<A extends Args>(
 
   const values = Object.create(null) as ArgValues<A>
   const errors: Error[] = []
-  const explicit = Object.create(null) as ExplicitlyProvided<A>
+  const explicit = Object.create(null) as ArgExplicitlyProvided<A>
 
   function checkTokenName(option: string, schema: ArgSchema, token: ArgToken): boolean {
     return (

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -391,6 +391,7 @@ export function resolveArgs<A extends Args>(
     const arg = toKebab || schema.toKebab ? kebabnize(rawArg) : rawArg
 
     // Initialize explicit state for all options
+    // keyof explicit is generic and cannot be indexed for settings value.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ;(explicit as any)[rawArg] = false
 
@@ -442,6 +443,7 @@ export function resolveArgs<A extends Args>(
         }
 
         // Mark as explicitly set when we find a matching token
+        // keyof explicit is generic and cannot be indexed for settings value.
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         ;(explicit as any)[rawArg] = true
 

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -178,7 +178,7 @@ const SKIP_POSITIONAL_DEFAULT = -1
  * provided (true) or is using a default value or not provided (false).
  */
 export type ArgExplicitlyProvided<A extends Args> = {
-  readonly [K in keyof A]: boolean
+  [K in keyof A]: boolean
 }
 
 /**


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/args-tokens/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

While working on the second item of the linked issue, I realized that I need to export the `ExplicitlyProvided` type from this library to proceed.

Therefore, this PR exports the Explicitly Provided type from the library.

Additionally, exporting the type with its original name made it unclear what was explicitly provided. For this reason, I have renamed it to `ArgExplicitlyProvided`.

Also, to avoid unnecessarily restricting the type, the properties of the ‎`ArgExplicitlyProvided` type are no longer marked as readonly.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

- https://github.com/kazupon/args-tokens/issues/146
- https://github.com/kazupon/gunshi/issues/222

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed a type related to explicitly provided arguments for improved clarity and consistency across the application.
  * Updated related type annotations and exports to reflect the new naming.

* **Tests**
  * Adjusted type assertions in tests to use the updated type name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->