### PR TITLE
fix(resolver): correct handling of positional arguments with multiple: true and required: true

### DIFF
--- a/src/resolver.test.ts
+++ b/src/resolver.test.ts
@@ -827,6 +827,92 @@ describe('multiple values', () => {
     expect(positionals).toEqual(['eat'])
     expect(rest).toEqual([])
   })
+
+  test('positional + multiple', () => {
+    const argv = ['foo', 'bar']
+    const tokens = parseArgs(argv)
+    const { values } = resolveArgs(
+      {
+        files: {
+          type: 'positional',
+          multiple: true
+        }
+      },
+      tokens
+    )
+    expect(values.files).toEqual(['foo', 'bar'])
+  })
+
+  test('positional + multiple + skipPositional', () => {
+    const argv = ['foo', 'bar']
+    const tokens = parseArgs(argv)
+    const { values } = resolveArgs(
+      {
+        files: {
+          type: 'positional',
+          multiple: true
+        }
+      },
+      tokens,
+      {
+        skipPositional: 0
+      }
+    )
+    expect(values.files).toEqual(['bar'])
+  })
+
+  test('positional + multiple + required', () => {
+    const argv = ['foo', 'bar']
+    const tokens = parseArgs(argv)
+    const { values } = resolveArgs(
+      {
+        files: {
+          type: 'positional',
+          multiple: true,
+          required: true
+        }
+      },
+      tokens
+    )
+    expect(values.files).toEqual(['foo', 'bar'])
+  })
+
+  test('positional + multiple + required 2', () => {
+    const argv: string[] = []
+    const tokens = parseArgs(argv)
+    const { error } = resolveArgs(
+      {
+        files: {
+          type: 'positional',
+          multiple: true,
+          required: true
+        }
+      },
+      tokens
+    )
+    expect(error?.errors.length).toBe(1)
+    expect((error?.errors[0] as Error).message).toEqual("Positional argument 'files' is required")
+  })
+
+  test('positional + named', () => {
+    const argv = ['foo', 'bar', '--help']
+    const tokens = parseArgs(argv)
+    const { values } = resolveArgs(
+      {
+        files: {
+          type: 'positional',
+          multiple: true,
+          required: true
+        },
+        help: {
+          type: 'boolean'
+        }
+      },
+      tokens
+    )
+    expect(values.files).toEqual(['foo', 'bar'])
+    expect(values.help).toBeTruthy()
+  })
 })
 
 describe(`'toKebab' option`, () => {

--- a/src/resolver.test.ts
+++ b/src/resolver.test.ts
@@ -828,7 +828,7 @@ describe('multiple values', () => {
     expect(rest).toEqual([])
   })
 
-  test('positional + multiple', () => {
+  test('positional', () => {
     const argv = ['foo', 'bar']
     const tokens = parseArgs(argv)
     const { values } = resolveArgs(
@@ -843,7 +843,7 @@ describe('multiple values', () => {
     expect(values.files).toEqual(['foo', 'bar'])
   })
 
-  test('positional + multiple + skipPositional', () => {
+  test('positional + skipPositional', () => {
     const argv = ['foo', 'bar']
     const tokens = parseArgs(argv)
     const { values } = resolveArgs(
@@ -861,10 +861,10 @@ describe('multiple values', () => {
     expect(values.files).toEqual(['bar'])
   })
 
-  test('positional + multiple + required', () => {
+  test('positional + required', () => {
     const argv = ['foo', 'bar']
     const tokens = parseArgs(argv)
-    const { values } = resolveArgs(
+    const { values, error } = resolveArgs(
       {
         files: {
           type: 'positional',
@@ -874,10 +874,11 @@ describe('multiple values', () => {
       },
       tokens
     )
+    expect(error?.errors).toBeUndefined()
     expect(values.files).toEqual(['foo', 'bar'])
   })
 
-  test('positional + multiple + required 2', () => {
+  test('positional + required error', () => {
     const argv: string[] = []
     const tokens = parseArgs(argv)
     const { error } = resolveArgs(


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/args-tokens/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

1. Moved the `positional` block up to ensure it runs before the `required` check.
2. Added handling for `positional` + `multiple` cases.

### Linked Issues

https://github.com/kazupon/args-tokens/issues/192

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
