### PR TITLE
feat(resolver): add conflicts option for mutually exclusive arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,6 +533,44 @@ Custom parsing function for `type: 'custom'` arguments. Required when `type: 'cu
 }
 ```
 
+#### `conflicts` (optional)
+
+Specifies other options that cannot be used together with this option. When conflicting options are provided together, an `ArgResolveError` will be thrown.
+
+Conflicts only need to be defined on one side - if option A defines a conflict with option B, the conflict is automatically detected when both are used.
+
+<!-- eslint-skip -->
+
+```js
+{
+  // Single conflict
+  port: {
+    type: 'number',
+    conflicts: 'socket'  // Cannot use --port with --socket
+  },
+  socket: {
+    type: 'string'
+    // No need to define conflicts: 'port' here
+  }
+}
+
+// Multiple conflicts (mutually exclusive options)
+{
+  tcp: {
+    type: 'number',
+    conflicts: ['udp', 'unix']  // Cannot use with --udp or --unix
+  },
+  udp: {
+    type: 'number',
+    conflicts: ['tcp', 'unix']
+  },
+  unix: {
+    type: 'string',
+    conflicts: ['tcp', 'udp']
+  }
+}
+```
+
 ## 🙌 Contributing guidelines
 
 If you are interested in contributing to `args-tokens`, I highly recommend checking out [the contributing guidelines](/CONTRIBUTING.md) here. You'll find all the relevant information such as [how to make a PR](/CONTRIBUTING.md#pull-request-guidelines), [how to setup development](/CONTRIBUTING.md#development-setup)) etc., there.

--- a/src/resolver.test.ts
+++ b/src/resolver.test.ts
@@ -1272,6 +1272,9 @@ describe('conflicts', () => {
 
     expect(error).toBeDefined()
     expect(error?.errors.length).toBe(1)
+    expect((error?.errors[0] as ArgResolveError).message).toBe(
+      "Optional argument '--transport' conflicts with '--socket'"
+    )
   })
 
   test('detects conflict with asymmetric conflict definitions', () => {

--- a/src/resolver.test.ts
+++ b/src/resolver.test.ts
@@ -1348,7 +1348,32 @@ describe('conflicts', () => {
     expect(error).toBeDefined()
     expect(error?.errors.length).toBe(1)
     expect((error?.errors[0] as ArgResolveError).message).toBe(
-      "Optional argument '--summer' or '-s' conflicts with '--autumn'"
+      "Optional argument '-s' conflicts with '-a'"
+    )
+  })
+
+  test('error message reflects actual input forms (long vs short)', () => {
+    const args = {
+      summer: {
+        type: 'boolean',
+        short: 's',
+        conflicts: 'autumn'
+      },
+      autumn: {
+        type: 'boolean',
+        short: 'a',
+        conflicts: 'summer'
+      }
+    } as const satisfies Args
+
+    const argv = ['--summer', '-a']
+    const tokens = parseArgs(argv)
+    const { error } = resolveArgs(args, tokens)
+
+    expect(error).toBeDefined()
+    expect(error?.errors.length).toBe(1)
+    expect((error?.errors[0] as ArgResolveError).message).toBe(
+      "Optional argument '--summer' conflicts with '-a'"
     )
   })
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/args-tokens/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR adds a new `conflicts` option to the `ArgSchema` interface that allows defining mutually exclusive command-line arguments. When conflicting options are used together, the resolver throws an `ArgResolveError` with type 'conflict'.

**Key features:**
- Support for both single conflict (`conflicts: 'other'`) and multiple conflicts (`conflicts: ['opt1', 'opt2']`)
- Bidirectional conflict detection - defining a conflict on either side is sufficient
- Clear error messages indicating which options are in conflict
- Works with both long and short option forms

**Example usage:**
```ts
const schema = {
  verbose: { type: 'boolean', conflicts: 'quiet' },
  quiet: { type: 'boolean', conflicts: 'verbose' }
}
```


### Linked Issues

Resolves #195 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for declaring mutually exclusive options in argument schemas. If conflicting options are provided together, an error will be shown.
  * Error messages now clearly indicate which options are in conflict, reflecting the actual input form (e.g., short or long option names).

* **Documentation**
  * Updated documentation with details and examples on how to use the new conflicts property in argument schemas.

* **Tests**
  * Added comprehensive tests to verify conflict detection and error messaging for various scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->