### PR TITLE
fix: track if positional arguments were explicitly provided

### DIFF
--- a/src/resolver.test.ts
+++ b/src/resolver.test.ts
@@ -1118,6 +1118,171 @@ describe('explicit provision detection', () => {
       expect(explicit.port).toBe(false)
     })
   })
+
+  describe('one positional argument', () => {
+    test('value provided', () => {
+      const schema = {
+        command: {
+          type: 'positional'
+        },
+        verbose: {
+          type: 'boolean'
+        }
+      } as const satisfies Args
+
+      const argv = ['--verbose', 'dev']
+      const tokens = parseArgs(argv)
+      const { explicit } = resolveArgs(schema, tokens)
+
+      expect(explicit.command).toBe(true)
+    })
+
+    test('value provided and same as default', () => {
+      const schema = {
+        out: {
+          type: 'positional',
+          default: 'dist'
+        },
+        verbose: {
+          type: 'boolean'
+        }
+      } as const satisfies Args
+
+      const argv = ['--verbose', 'dist']
+      const tokens = parseArgs(argv)
+      const { explicit } = resolveArgs(schema, tokens)
+
+      expect(explicit.out).toBe(true)
+    })
+
+    test('value not provided', () => {
+      const schema = {
+        out: {
+          type: 'positional',
+          default: 'dist'
+        },
+        verbose: {
+          type: 'boolean'
+        }
+      } as const satisfies Args
+
+      const argv = ['--verbose']
+      const tokens = parseArgs(argv)
+      const { explicit } = resolveArgs(schema, tokens)
+
+      expect(explicit.out).toBe(false)
+    })
+
+    test('value provided for multiple: true', () => {
+      const schema = {
+        files: {
+          type: 'positional',
+          multiple: true
+        },
+        verbose: {
+          type: 'boolean'
+        }
+      } as const satisfies Args
+
+      const argv = ['--verbose', 'file1.ts']
+      const tokens = parseArgs(argv)
+      const { explicit } = resolveArgs(schema, tokens)
+
+      expect(explicit.files).toBe(true)
+    })
+
+    test('value not provided for multiple: true', () => {
+      const schema = {
+        files: {
+          type: 'positional',
+          multiple: true
+        },
+        verbose: {
+          type: 'boolean'
+        }
+      } as const satisfies Args
+
+      const argv = ['--verbose']
+      const tokens = parseArgs(argv)
+      const { explicit } = resolveArgs(schema, tokens)
+
+      expect(explicit.files).toBe(false)
+    })
+  })
+
+  describe('many positional arguments', () => {
+    const schema = {
+      from: {
+        type: 'positional'
+      },
+      to: {
+        type: 'positional'
+      },
+      verbose: {
+        type: 'boolean'
+      }
+    } as const satisfies Args
+
+    test('value provided', () => {
+      const argv = ['--verbose', 'source.txt', 'dest.txt']
+
+      const tokens = parseArgs(argv)
+      const { explicit } = resolveArgs(schema, tokens)
+
+      expect(explicit).toMatchObject({
+        from: true,
+        to: true
+      })
+    })
+
+    test('value partially provided', () => {
+      const argv = ['--verbose', 'source.txt']
+
+      const tokens = parseArgs(argv)
+      const { explicit } = resolveArgs(schema, tokens)
+
+      expect(explicit).toMatchObject({
+        from: true,
+        to: false
+      })
+    })
+
+    test('value not provided', () => {
+      const argv = ['--verbose']
+
+      const tokens = parseArgs(argv)
+      const { explicit } = resolveArgs(schema, tokens)
+
+      expect(explicit).toMatchObject({
+        from: false,
+        to: false
+      })
+    })
+
+    test('value provided for multiple: true', () => {
+      const schema = {
+        command: {
+          type: 'positional'
+        },
+        files: {
+          type: 'positional',
+          multiple: true
+        },
+        verbose: {
+          type: 'boolean'
+        }
+      } as const satisfies Args
+
+      const argv = ['--verbose', 'compile', 'file1.ts']
+      const tokens = parseArgs(argv)
+      const { explicit } = resolveArgs(schema, tokens)
+
+      expect(explicit).toMatchObject({
+        command: true,
+        files: true
+      })
+    })
+  })
 })
 
 describe('conflicts', () => {

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -790,6 +790,9 @@ export function resolveArgs<A extends Args>(
           // eslint-disable-next-line @typescript-eslint/no-explicit-any -- NOTE(kazupon): Allow any type for resolving
           ;(values as any)[rawArg] = remainingPositionals.map(p => p.value!)
           positionalsCount += remainingPositionals.length
+          // mark as explicitly set when positional arguments are provided.
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- NOTE(sushichan044): Allow any type for resolving
+          ;(explicit as any)[rawArg] = true
         } else if (schema.required) {
           errors.push(createRequireError(arg, schema))
         }
@@ -799,6 +802,9 @@ export function resolveArgs<A extends Args>(
         if (positional != null) {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any -- NOTE(kazupon): Allow any type for resolving
           ;(values as any)[rawArg] = positional.value!
+          // mark as explicitly set when positional argument is provided.
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- NOTE(sushichan044): Allow any type for resolving
+          ;(explicit as any)[rawArg] = true
         } else {
           errors.push(createRequireError(arg, schema))
         }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/args-tokens/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->


### Description

> [!NOTE]
> Reviewing each commit is recommended.

This PR extends explicitly-provided checking to positional arguments, a feature introduced for flags by https://github.com/kazupon/args-tokens/pull/161.

As of #161, `explicit[positional]` was always false, so this change fixes that bug.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

- f7c2a919b5f4289072d38fd95f4e41794fbd4260 tidying up existing test cases and tagging them
- 359b6e42af6ce3c6babfb9f3e253551fec6808f9 fixing the bug and testing behavior



After merging this PR, it is recommended to update the version of args-tokens used by gunshi.
<!-- e.g. is there anything you'd like reviewers to focus on? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tracking of explicitly provided positional arguments for better conflict resolution and validation.

* **Tests**
  * Added comprehensive test suite covering various argument patterns including options, defaults, flags, and positional arguments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->