### PR TITLE
perf(resolver): optimize positional argument resolution

### DIFF
--- a/bench/positionals.js
+++ b/bench/positionals.js
@@ -1,0 +1,79 @@
+import { barplot, bench, run } from 'mitata'
+import { parseArgs, resolveArgs } from '../lib/index.js'
+
+const cases = [
+  {
+    name: 'options only',
+    argv: ['dev', '--foo', '--bar=3', '-b=4', 'left', 'right'],
+    schema: {
+      foo: { type: 'boolean', short: 'f' },
+      bar: { type: 'number', short: 'b', required: true }
+    }
+  },
+  {
+    name: 'one required positional',
+    argv: ['build', '--foo', '--bar=3', 'extra'],
+    schema: {
+      command: { type: 'positional' },
+      foo: { type: 'boolean', short: 'f' },
+      bar: { type: 'number', short: 'b', required: true }
+    }
+  },
+  {
+    name: 'optional trailing missing',
+    argv: ['--help'],
+    schema: {
+      query: { type: 'positional', required: false },
+      help: { type: 'boolean', short: 'h' }
+    }
+  },
+  {
+    name: 'optional before required',
+    argv: ['users'],
+    schema: {
+      query: { type: 'positional', required: false },
+      table: { type: 'positional' }
+    }
+  },
+  {
+    name: 'optional before required full',
+    argv: ['select *', 'users'],
+    schema: {
+      query: { type: 'positional', required: false },
+      table: { type: 'positional' }
+    }
+  },
+  {
+    name: 'multiple before required',
+    argv: ['a.ts', 'b.ts', 'c.ts', 'out.js'],
+    schema: {
+      files: { type: 'positional', multiple: true },
+      output: { type: 'positional' }
+    }
+  },
+  {
+    name: 'long positional chain',
+    argv: ['ns', 'query', 'users', 'json', 'pretty'],
+    schema: {
+      namespace: { type: 'positional', required: false },
+      query: { type: 'positional', required: false },
+      table: { type: 'positional' },
+      format: { type: 'positional', required: false },
+      style: { type: 'positional', required: false }
+    }
+  }
+]
+
+for (const testCase of cases) {
+  testCase.tokens = parseArgs(testCase.argv)
+}
+
+barplot(() => {
+  for (const testCase of cases) {
+    bench(testCase.name, () => {
+      resolveArgs(testCase.schema, testCase.tokens)
+    })
+  }
+})
+
+await run()

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -2,7 +2,7 @@ import type { KnipConfig } from 'knip'
 
 const config: KnipConfig = {
   entry: ['playground/bun/index.ts'],
-  ignore: ['playground/deno/**', 'bench/mitata.js'],
+  ignore: ['playground/deno/**', 'bench/mitata.js', 'bench/positionals.js'],
   ignoreDependencies: [
     'lint-staged',
     'mitata',

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
   },
   "scripts": {
     "bench:mitata": "node --expose-gc bench/mitata.js",
+    "bench:positionals": "node --expose-gc bench/positionals.js",
     "bench:vitest": "vitest bench --run",
     "build": "tsdown",
     "build:docs": "node scripts/generate-docs.mjs",

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -838,67 +838,76 @@ export function resolveArgs<A extends Args>(
         }
       }
 
-      const requiredPositionals = getRequiredPositionalsAfter(rawArg)
-      const availablePositionals = Math.max(positionalTokens.length - positionalsCount, 0)
-
       if (schema.multiple) {
-        const positionalsToConsume = Math.max(availablePositionals - requiredPositionals, 0)
-        const remainingPositionals = positionalTokens.slice(
-          positionalsCount,
-          positionalsCount + positionalsToConsume
-        )
-        if (remainingPositionals.length > 0) {
-          if (typeof schema.parse === 'function') {
-            const parsed: unknown[] = []
-            for (const p of remainingPositionals) {
-              try {
-                parsed.push(schema.parse(p.value!))
-              } catch (error) {
-                errors.push(error as Error)
+        const availablePositionals = Math.max(positionalTokens.length - positionalsCount, 0)
+        if (availablePositionals > 0) {
+          const requiredPositionals = getRequiredPositionalsAfter(rawArg)
+          const positionalsToConsume = Math.max(availablePositionals - requiredPositionals, 0)
+          if (positionalsToConsume > 0) {
+            const endPositionals = positionalsCount + positionalsToConsume
+            if (typeof schema.parse === 'function') {
+              const parsed: unknown[] = []
+              for (let i = positionalsCount; i < endPositionals; i++) {
+                const p = positionalTokens[i]
+                try {
+                  parsed.push(schema.parse(p.value!))
+                } catch (error) {
+                  errors.push(error as Error)
+                }
               }
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- NOTE(kazupon): Allow any type for resolving
+              ;(values as any)[rawArg] = parsed
+            } else {
+              const valuesArray: string[] = []
+              for (let i = positionalsCount; i < endPositionals; i++) {
+                valuesArray.push(positionalTokens[i].value!)
+              }
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- NOTE(kazupon): Allow any type for resolving
+              ;(values as any)[rawArg] = valuesArray
             }
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- NOTE(kazupon): Allow any type for resolving
-            ;(values as any)[rawArg] = parsed
-          } else {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- NOTE(kazupon): Allow any type for resolving
-            ;(values as any)[rawArg] = remainingPositionals.map(p => p.value!)
+            positionalsCount = endPositionals
+            // mark as explicitly set when positional arguments are provided.
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- NOTE(sushichan044): Allow any type for resolving
+            ;(explicit as any)[rawArg] = true
+          } else if (schema.required) {
+            errors.push(createRequireError(arg, schema))
           }
-          positionalsCount += remainingPositionals.length
-          // mark as explicitly set when positional arguments are provided.
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- NOTE(sushichan044): Allow any type for resolving
-          ;(explicit as any)[rawArg] = true
         } else if (schema.required) {
           errors.push(createRequireError(arg, schema))
         }
       } else {
         const positional = positionalTokens[positionalsCount]
-        const shouldConsumePositional =
-          positional != null &&
-          (shouldRequireMissingSinglePositional(schema) ||
-            availablePositionals > requiredPositionals)
-        if (shouldConsumePositional) {
-          if (typeof schema.parse === 'function') {
-            try {
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment -- NOTE(kazupon): Allow any type for resolving
-              ;(values as any)[rawArg] = schema.parse(positional.value!)
-            } catch (error) {
-              errors.push(error as Error)
-            }
+
+        if (shouldRequireMissingSinglePositional(schema)) {
+          if (positional != null) {
+            resolveSinglePositionalValue(values, errors, rawArg, schema, positional)
+            // mark as explicitly set when positional argument is provided.
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- NOTE(sushichan044): Allow any type for resolving
+            ;(explicit as any)[rawArg] = true
+            positionalsCount++
           } else {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- NOTE(kazupon): Allow any type for resolving
-            ;(values as any)[rawArg] = positional.value!
-          }
-          // mark as explicitly set when positional argument is provided.
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- NOTE(sushichan044): Allow any type for resolving
-          ;(explicit as any)[rawArg] = true
-          positionalsCount++
-        } else {
-          if (shouldRequireMissingSinglePositional(schema)) {
             errors.push(createRequireError(arg, schema))
-          } else if (hasDefault(schema)) {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- NOTE(kazupon): Allow any type for resolving
-            ;(values as any)[rawArg] = schema.default
           }
+          continue
+        }
+
+        if (positional != null) {
+          const requiredPositionals = getRequiredPositionalsAfter(rawArg)
+          const availablePositionals = Math.max(positionalTokens.length - positionalsCount, 0)
+
+          if (availablePositionals > requiredPositionals) {
+            resolveSinglePositionalValue(values, errors, rawArg, schema, positional)
+            // mark as explicitly set when positional argument is provided.
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- NOTE(sushichan044): Allow any type for resolving
+            ;(explicit as any)[rawArg] = true
+            positionalsCount++
+            continue
+          }
+        }
+
+        if (hasDefault(schema)) {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- NOTE(kazupon): Allow any type for resolving
+          ;(values as any)[rawArg] = schema.default
         }
       }
       continue
@@ -1043,6 +1052,24 @@ function createRequireError(option: string, schema: ArgSchema): ArgResolveError 
       ? `Positional argument '${option}' is required`
       : `Optional argument '--${option}' ${schema.short ? `or '-${schema.short}' ` : ''}is required`
   return new ArgResolveError(message, option, 'required', schema)
+}
+
+function resolveSinglePositionalValue(
+  values: Record<string, unknown>,
+  errors: Error[],
+  rawArg: string,
+  schema: ArgSchema,
+  positional: ArgToken
+): void {
+  if (typeof schema.parse === 'function') {
+    try {
+      values[rawArg] = schema.parse(positional.value!)
+    } catch (error) {
+      errors.push(error as Error)
+    }
+  } else {
+    values[rawArg] = positional.value!
+  }
 }
 
 function hasDefault(schema: ArgSchema): boolean {


### PR DESCRIPTION
## Summary
This PR reduces the positional argument resolver overhead introduced by optional and multiple positional support. It keeps the required single positional path from building the required-positionals cache, skips reservation work when optional positionals are missing, and replaces slice/map allocation in multiple positionals with indexed loops. A focused mitata benchmark now covers required, optional, multiple, and chained positional cases to make future regressions visible before future releases.

## Verification
- `pnpm test`
- `pnpm build`
- `pnpm lint`
- `pnpm bench:positionals`
- `git diff --check`

## Benchmark Notes
- Required positional: +8.6% vs main
- Optional trailing missing: +11.7% vs main
- Multiple before required: +10.6% vs main


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive performance benchmarks for various positional argument scenarios and edge cases.

* **Refactor**
  * Refactored positional argument resolution with improved handling of required and optional arguments, better error management, and more precise consumption tracking.

* **Chores**
  * Updated configuration and development tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->