### PR TITLE
fix(resolver): keep positionals after kebab-case boolean options

### DIFF
--- a/src/resolver.test.ts
+++ b/src/resolver.test.ts
@@ -2366,25 +2366,6 @@ describe('schema.parse priority', () => {
     expect(nonHyphenatedBoolean.positionals).toEqual(['app.js'])
   })
 
-  test('analyze phase: global toKebab boolean followed by positional', () => {
-    const { values, positionals } = resolveArgs(
-      {
-        file: {
-          type: 'positional',
-          required: false
-        },
-        enableLogging: {
-          type: 'boolean'
-        }
-      },
-      parseArgs(['--enable-logging', 'app.js']),
-      { toKebab: true }
-    )
-    expect(values.enableLogging).toBe(true)
-    expect(values.file).toBe('app.js')
-    expect(positionals).toEqual(['app.js'])
-  })
-
   test('analyze phase: negatable kebab-case boolean followed by positional', () => {
     const { values, positionals } = resolveArgs(
       {

--- a/src/resolver.test.ts
+++ b/src/resolver.test.ts
@@ -2366,6 +2366,25 @@ describe('schema.parse priority', () => {
     expect(nonHyphenatedBoolean.positionals).toEqual(['app.js'])
   })
 
+  test('analyze phase: global toKebab boolean followed by positional', () => {
+    const schema = {
+      file: {
+        type: 'positional',
+        required: false
+      },
+      enableLogging: {
+        type: 'boolean'
+      }
+    } as const
+
+    const { values, positionals } = resolveArgs(schema, parseArgs(['--enable-logging', 'app.js']), {
+      toKebab: true
+    })
+    expect(values.enableLogging).toBe(true)
+    expect(values.file).toBe('app.js')
+    expect(positionals).toEqual(['app.js'])
+  })
+
   test('analyze phase: negatable kebab-case boolean followed by positional', () => {
     const { values, positionals } = resolveArgs(
       {

--- a/src/resolver.test.ts
+++ b/src/resolver.test.ts
@@ -2333,6 +2333,77 @@ describe('schema.parse priority', () => {
     expect(values.port).toBe(8080)
     expect(positionals).toEqual(['foo'])
   })
+
+  test('analyze phase: kebab-case boolean followed by positional', () => {
+    const schema = {
+      file: {
+        type: 'positional',
+        required: false
+      },
+      enableLogging: {
+        type: 'boolean',
+        toKebab: true
+      },
+      force: {
+        type: 'boolean',
+        toKebab: true
+      }
+    } as const
+
+    const flagThenPositional = resolveArgs(schema, parseArgs(['--enable-logging', 'app.js']))
+    expect(flagThenPositional.values.enableLogging).toBe(true)
+    expect(flagThenPositional.values.file).toBe('app.js')
+    expect(flagThenPositional.positionals).toEqual(['app.js'])
+
+    const positionalThenFlag = resolveArgs(schema, parseArgs(['app.js', '--enable-logging']))
+    expect(positionalThenFlag.values.enableLogging).toBe(true)
+    expect(positionalThenFlag.values.file).toBe('app.js')
+    expect(positionalThenFlag.positionals).toEqual(['app.js'])
+
+    const nonHyphenatedBoolean = resolveArgs(schema, parseArgs(['--force', 'app.js']))
+    expect(nonHyphenatedBoolean.values.force).toBe(true)
+    expect(nonHyphenatedBoolean.values.file).toBe('app.js')
+    expect(nonHyphenatedBoolean.positionals).toEqual(['app.js'])
+  })
+
+  test('analyze phase: global toKebab boolean followed by positional', () => {
+    const { values, positionals } = resolveArgs(
+      {
+        file: {
+          type: 'positional',
+          required: false
+        },
+        enableLogging: {
+          type: 'boolean'
+        }
+      },
+      parseArgs(['--enable-logging', 'app.js']),
+      { toKebab: true }
+    )
+    expect(values.enableLogging).toBe(true)
+    expect(values.file).toBe('app.js')
+    expect(positionals).toEqual(['app.js'])
+  })
+
+  test('analyze phase: negatable kebab-case boolean followed by positional', () => {
+    const { values, positionals } = resolveArgs(
+      {
+        file: {
+          type: 'positional',
+          required: false
+        },
+        enableLogging: {
+          type: 'boolean',
+          toKebab: true,
+          negatable: true
+        }
+      },
+      parseArgs(['--no-enable-logging', 'app.js'])
+    )
+    expect(values.enableLogging).toBe(false)
+    expect(values.file).toBe('app.js')
+    expect(positionals).toEqual(['app.js'])
+  })
 })
 
 /* oxlint-enable no-unsafe-optional-chaining */

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -811,7 +811,14 @@ export function resolveArgs<A extends Args>(
           applyShortOptionValue(token.value)
         }
       } else if (currentLongOption) {
-        const isBoolean = args[currentLongOption.name!]?.type === 'boolean'
+        const isBoolean = Object.entries(args).some(([rawArg, schema]) => {
+          if (schema.type !== 'boolean') {
+            return false
+          }
+          const option = toKebab || schema.toKebab ? kebabnize(rawArg) : rawArg
+          const name = currentLongOption!.name
+          return name === option || (schema.negatable === true && name === `no-${option}`)
+        })
         if (isBoolean) {
           positionalTokens.push({ ...token })
           applyLongOptionValue() // finalize boolean without value

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -790,6 +790,17 @@ export function resolveArgs<A extends Args>(
    */
 
   const schemas = Object.values(args)
+  const booleanLongOptionNames = new Set<string>()
+  for (const [rawArg, schema] of Object.entries(args)) {
+    if (schema.type !== 'boolean') {
+      continue
+    }
+    const arg = toKebab || schema.toKebab ? kebabnize(rawArg) : rawArg
+    booleanLongOptionNames.add(arg)
+    if (schema.negatable === true) {
+      booleanLongOptionNames.add(`no-${arg}`)
+    }
+  }
   let terminated = false
 
   for (let i = 0; i < tokens.length; i++) {
@@ -811,15 +822,7 @@ export function resolveArgs<A extends Args>(
           applyShortOptionValue(token.value)
         }
       } else if (currentLongOption) {
-        const isBoolean = Object.entries(args).some(([rawArg, schema]) => {
-          if (schema.type !== 'boolean') {
-            return false
-          }
-          const arg = toKebab || schema.toKebab ? kebabnize(rawArg) : rawArg
-          const name = currentLongOption!.name
-          return name === arg || (schema.negatable === true && name === `no-${arg}`)
-        })
-        if (isBoolean) {
+        if (booleanLongOptionNames.has(currentLongOption.name!)) {
           positionalTokens.push({ ...token })
           applyLongOptionValue() // finalize boolean without value
         } else {

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -815,9 +815,9 @@ export function resolveArgs<A extends Args>(
           if (schema.type !== 'boolean') {
             return false
           }
-          const option = toKebab || schema.toKebab ? kebabnize(rawArg) : rawArg
+          const arg = toKebab || schema.toKebab ? kebabnize(rawArg) : rawArg
           const name = currentLongOption!.name
-          return name === option || (schema.negatable === true && name === `no-${option}`)
+          return name === arg || (schema.negatable === true && name === `no-${arg}`)
         })
         if (isBoolean) {
           positionalTokens.push({ ...token })


### PR DESCRIPTION
### Description

`resolveArgs` mishandles this combination:

1. a **positional** argument in the schema
2. a **boolean** option whose schema key is camelCase with `toKebab: true` (CLI flag becomes hyphenated, e.g. `enableLogging` → `--enable-logging`)
3. argv order: the boolean flag, then the positional value

Result: the boolean becomes `true`, but the following token is **not** assigned to the positional (`values.file` / `positionals` are empty). It is treated as the boolean option's value and discarded.

Non-hyphenated booleans are fine (`force` → `--force`). Putting the positional before the flag is also fine.

#### Expected

`['--enable-logging', 'app.js']` should set both `enableLogging: true` and positional `file: 'app.js'`.

#### Cause

In the analyze phase of `resolveArgs`, boolean detection used:

```ts
const isBoolean = args[currentLongOption.name!]?.type === 'boolean'
```

For `--enable-logging`, `currentLongOption.name` is `"enable-logging"`, but the schema key is `"enableLogging"`, so the lookup fails. Later matching already uses `kebabnize` when `toKebab` is set; the analyze-phase lookup did not.

#### Fix

Resolve boolean schemas in the analyze phase with the same `toKebab` / `kebabnize` logic (and `no-` for `negatable`) used later in `resolveArgs`.

#### Minimal repro

```js
import { parseArgs, resolveArgs } from 'args-tokens'

const args = {
  file: { type: 'positional', required: false },
  enableLogging: { type: 'boolean', toKebab: true }, // → --enable-logging
  force: { type: 'boolean', toKebab: true }, // → --force (control)
}

const run = (argv) => {
  const { values, positionals } = resolveArgs(args, parseArgs(argv))
  return { values, positionals }
}

// BUG (before): flag then positional
run(['--enable-logging', 'app.js'])
// actual:   { values: { enableLogging: true }, positionals: [] }
// expected: { values: { enableLogging: true, file: 'app.js' }, positionals: ['app.js'] }

// OK: positional then flag
run(['app.js', '--enable-logging'])

// OK: non-hyphenated boolean + positional
run(['--force', 'app.js'])
````

### Linked Issues

N/A (bug fix PR without a prior issue)

### Additional context

- Also affects negatable flags like `--no-enable-logging` followed by a positional
- Regression tests cover per-arg `toKebab` and negatable kebab-case booleans followed by a positional

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing for kebab-case boolean command-line options.
  * Boolean flags now correctly associate with adjacent optional positional arguments, regardless of whether the flag appears before or after the positional.
  * Fixed support for negatable boolean flags (for example, `--no-...`), including correct `false` handling.
  * Preserved correct resolution when kebab-case conversion is enabled, including support for non-hyphenated boolean forms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->