### PR TITLE
fix: normalize negatable option resolution

### DIFF
--- a/src/resolver.test.ts
+++ b/src/resolver.test.ts
@@ -176,6 +176,27 @@ describe('resolveArgs', () => {
     expect(rest).toEqual([])
   })
 
+  test('required negatable boolean accepts negated long option', () => {
+    const argv = ['--no-color']
+    const tokens = parseArgs(argv)
+    const { values, error, explicit } = resolveArgs(
+      {
+        color: {
+          type: 'boolean',
+          negatable: true,
+          required: true
+        }
+      },
+      tokens
+    )
+
+    expect(error).toBeUndefined()
+    expect(values).toEqual({
+      color: false
+    })
+    expect(explicit.color).toBe(true)
+  })
+
   test('short options value specified with equals', () => {
     const argv = ['dev', '-p=9131', '-o=example.com', '-h']
     const tokens = parseArgs(argv)
@@ -1581,6 +1602,28 @@ describe(`'toKebab' option`, () => {
     })
   })
 
+  test('per argument required negatable boolean accepts negated kebab-case long option', () => {
+    const argv = ['--no-kebab-case']
+    const tokens = parseArgs(argv)
+    const { values, error, explicit } = resolveArgs(
+      {
+        kebabCase: {
+          type: 'boolean',
+          negatable: true,
+          required: true,
+          toKebab: true
+        }
+      },
+      tokens
+    )
+
+    expect(error).toBeUndefined()
+    expect(values).toEqual({
+      kebabCase: false
+    })
+    expect(explicit.kebabCase).toBe(true)
+  })
+
   test('all arguments', () => {
     const argv = ['test', '--to-kebab=foo', '--no-kebab-case', '--foo-bar']
     const tokens = parseArgs(argv)
@@ -1608,6 +1651,28 @@ describe(`'toKebab' option`, () => {
       toKebab: true,
       kebabCase: false
     })
+  })
+
+  test('global required negatable boolean accepts negated kebab-case long option', () => {
+    const argv = ['--no-kebab-case']
+    const tokens = parseArgs(argv)
+    const { values, error, explicit } = resolveArgs(
+      {
+        kebabCase: {
+          type: 'boolean',
+          negatable: true,
+          required: true
+        }
+      },
+      tokens,
+      { toKebab: true }
+    )
+
+    expect(error).toBeUndefined()
+    expect(values).toEqual({
+      kebabCase: false
+    })
+    expect(explicit.kebabCase).toBe(true)
   })
 })
 
@@ -2149,6 +2214,30 @@ describe('conflicts', () => {
     expect(error).toBeDefined()
     expect((error?.errors[0] as ArgResolveError).message).toBe(
       "Optional argument '--summer-season' conflicts with '--autumn-season'"
+    )
+  })
+
+  test('conflict error message preserves negated long option input', () => {
+    const args = {
+      color: {
+        type: 'boolean',
+        negatable: true,
+        conflicts: 'format'
+      },
+      format: {
+        type: 'string',
+        conflicts: 'color'
+      }
+    } as const satisfies Args
+
+    const argv = ['--no-color', '--format=json']
+    const tokens = parseArgs(argv)
+    const { error } = resolveArgs(args, tokens)
+
+    expect(error).toBeDefined()
+    expect(error?.errors.length).toBe(1)
+    expect((error?.errors[0] as ArgResolveError).message).toBe(
+      "Optional argument '--no-color' conflicts with '--format'"
     )
   })
 

--- a/src/resolver.test.ts
+++ b/src/resolver.test.ts
@@ -176,6 +176,18 @@ describe('resolveArgs', () => {
     expect(rest).toEqual([])
   })
 
+  test('long option matching a short alias does not satisfy required option', () => {
+    const tokens = parseArgs(['--o=example.com'])
+    const { error } = resolveArgs(args, tokens)
+
+    expect(
+      error?.errors.some(
+        item =>
+          (item as ArgResolveError).name === 'host' && (item as ArgResolveError).type === 'required'
+      )
+    ).toBe(true)
+  })
+
   test('required negatable boolean accepts negated long option', () => {
     const argv = ['--no-color']
     const tokens = parseArgs(argv)

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1024,7 +1024,11 @@ export function resolveArgs<A extends Args>(
     if (schema.required) {
       const found = optionTokens.find(token => {
         return (
-          (schema.short && token.name === schema.short) || checkLongTokenName(arg, schema, token)
+          (schema.short &&
+            token.name === schema.short &&
+            token.rawName != undefined &&
+            isShortOption(token.rawName)) ||
+          checkLongTokenName(arg, schema, token)
         )
       })
       if (!found) {

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -753,10 +753,26 @@ export function resolveArgs<A extends Args>(
 
   const optionTokens: ArgToken[] = []
   const positionalTokens: ArgToken[] = []
+  const argEntries = Object.entries(args)
 
   let currentLongOption: ArgToken | undefined
   let currentShortOption: ArgToken | undefined
   const expandableShortOptions: ArgToken[] = []
+
+  function getOptionName(rawArg: string, schema: ArgSchema): string {
+    return toKebab || schema.toKebab ? kebabnize(rawArg) : rawArg
+  }
+
+  function checkLongTokenName(option: string, schema: ArgSchema, token: ArgToken): boolean {
+    if (token.rawName == undefined || !hasLongOptionPrefix(token.rawName)) {
+      return false
+    }
+
+    return (
+      token.name === option ||
+      (schema.type === 'boolean' && schema.negatable === true && token.name === `no-${option}`)
+    )
+  }
 
   function toShortValue(): string | undefined {
     if (expandableShortOptions.length === 0) {
@@ -901,19 +917,7 @@ export function resolveArgs<A extends Args>(
   const errors: Error[] = []
   const explicit = Object.create(null) as ArgExplicitlyProvided<A>
   const actualInputNames = new Map<string, string>()
-  const argEntries = Object.entries(args)
   let requiredPositionalsAfter: Record<string, number> | undefined
-
-  function checkTokenName(option: string, schema: ArgSchema, token: ArgToken): boolean {
-    return (
-      token.name ===
-      (schema.type === 'boolean'
-        ? schema.negatable && token.name?.startsWith('no-')
-          ? `no-${option}`
-          : option
-        : option)
-    )
-  }
 
   const positionalItemCount = tokens.filter(token => token.kind === 'positional').length
   function getPositionalSkipIndex() {
@@ -927,7 +931,7 @@ export function resolveArgs<A extends Args>(
 
   let positionalsCount = 0
   for (const [rawArg, schema] of argEntries) {
-    const arg = toKebab || schema.toKebab ? kebabnize(rawArg) : rawArg
+    const arg = getOptionName(rawArg, schema)
 
     // initialize explicit state for all options.
     // keyof explicit is generic and cannot be indexed for settings value.
@@ -1020,8 +1024,7 @@ export function resolveArgs<A extends Args>(
     if (schema.required) {
       const found = optionTokens.find(token => {
         return (
-          (schema.short && token.name === schema.short) ||
-          (token.rawName && hasLongOptionPrefix(token.rawName) && token.name === arg)
+          (schema.short && token.name === schema.short) || checkLongTokenName(arg, schema, token)
         )
       })
       if (!found) {
@@ -1034,9 +1037,7 @@ export function resolveArgs<A extends Args>(
       const token = optionTokens[i]
 
       if (
-        (checkTokenName(arg, schema, token) &&
-          token.rawName != undefined &&
-          hasLongOptionPrefix(token.rawName)) ||
+        checkLongTokenName(arg, schema, token) ||
         (schema.short === token.name && token.rawName != undefined && isShortOption(token.rawName))
       ) {
         const invalid = validateRequire(token, rawArg, arg, schema)
@@ -1051,7 +1052,8 @@ export function resolveArgs<A extends Args>(
         ;(explicit as any)[rawArg] = true
 
         // Record the actual input name used (e.g., '-v' or '--verbose')
-        const actualInputName = isShortOption(token.rawName) ? `-${token.name}` : `--${arg}`
+        const rawName = token.rawName!
+        const actualInputName = isShortOption(rawName) ? `-${token.name}` : rawName
         actualInputNames.set(rawArg, actualInputName)
 
         const [parsedValue, error] = parse(token, rawArg, arg, schema)


### PR DESCRIPTION
### Description

Normalize schema-aware long-option matching across resolver phases so negated boolean forms are treated consistently.

This change:
- allows `--no-*` to satisfy `required: true` for negatable booleans
- supports both per-option and global `toKebab` conversion for those required checks
- preserves the actual negated input name in conflict errors
- reuses the same matching semantics while classifying boolean options during token analysis

Regression tests cover plain, per-option kebab-case, and global kebab-case negated required options, plus conflict display.

### Linked Issues

Fixes #552

### Additional context

Verification:
- `npx -y pnpm@11.14.0 test` — 251 tests passed; no type errors
- `npx -y pnpm@11.14.0 lint` — passed (Deno, ESLint, JSR dry run, Knip, Oxfmt, Oxlint)
- `npx -y pnpm@11.14.0 build` — passed
- `git diff --check` — passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing for required boolean options when provided using negated long-form input.
  * Fixed matching for kebab-case long options across both per-argument and global modes.
  * Updated conflict/error messages to reflect the original negated option syntax exactly as entered.
* **Tests**
  * Added additional coverage for required/negatable boolean resolution and conflict message rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->