### PR TITLE
refactor(release): generate changelog before tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ name: Release
 #     then release-notes on success of both.
 #   - workflow_dispatch: fallback recovery. Pick which job to run for an
 #     existing tag (npm-publish / jsr-publish / release-notes / all).
+#
+# CHANGELOG.md is already part of the tagged release commit produced by
+# `pnpm release`. This workflow does not generate or commit the changelog.
+# release-notes only creates the GitHub Release.
 on:
   push:
     branches-ignore:
@@ -125,34 +129,25 @@ jobs:
       )
     runs-on: ubuntu-latest
     permissions:
-      contents: write # GitHub Release creation + CHANGELOG push
+      contents: write # create GitHub Release
 
     steps:
-      - name: Checkout codes
-        # zizmor: ignore[artipacked] -- git-auto-commit-action needs persisted credentials to push.
+      - name: Checkout tag
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: main
-          fetch-depth: 0
+          ref: ${{ env.TAG }}
+          persist-credentials: false
 
-      - name: Create GitHub Release
+      - name: Create GitHub Release (idempotent)
         run: |
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "Release $TAG already exists, skipping creation"
           else
-            gh release create "$TAG" --generate-notes
+            FLAGS=(--verify-tag --generate-notes)
+            if [[ "$TAG" == *-* ]]; then
+              FLAGS+=(--prerelease)
+            fi
+            gh release create "$TAG" "${FLAGS[@]}"
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Sync changelog from GitHub Releases
-        run: npx gh-changelogen --repo=kazupon/args-tokens --tag="$TAG"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Commit changelog
-        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
-        with:
-          branch: main
-          file_pattern: CHANGELOG.md
-          commit_message: 'chore: generate changelog'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,7 +144,8 @@ jobs:
             echo "Release $TAG already exists, skipping creation"
           else
             FLAGS=(--verify-tag --generate-notes)
-            if [[ "$TAG" == *-* ]]; then
+            # SemVer prerelease: '-' after major.minor.patch, not build metadata.
+            if [[ "$TAG" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+- ]]; then
               FLAGS+=(--prerelease)
             fi
             gh release create "$TAG" "${FLAGS[@]}"

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 .DS_Store
 .idea
 .eslintcache
+.plans
 lib
 dist
 

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -96,6 +96,7 @@
     }
   ],
   "ignorePatterns": [
+    ".plans/**",
     ".vscode",
     "lib",
     "docs",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ pnpm bench:vitest # Run performance benchmarks with vitest
 ### Release
 
 ```bash
-pnpm release      # Create a new release
+GH_TOKEN="$(gh auth token)" pnpm release      # Create a new release
 ```
 
 ## Architecture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ pnpm fix          # Fix all issues (eslint, prettier, knip)
 pnpm fix:eslint   # Fix ESLint issues
 pnpm fix:prettier # Fix formatting
 
-pnpm typecheck    # Run TypeScript type checking (tsc and deno)
+pnpm typecheck    # Run TypeScript type checking (tsc --noEmit)
 ```
 
 ### Development

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,3 +62,16 @@ $ pnpm fix
 There are some other scripts available in the `scripts` section of the `package.json` file.
 
 **Please make sure to have this pass successfully before submitting a PR.** Although the lint will be run against your PR on the CI server, it is better to have it working locally beforehand.
+
+### `pnpm release`
+
+Bump versions, write `CHANGELOG.md` from GitHub-generated notes, then commit,
+tag, and push. Run on a clean `main` whose `HEAD` is already on `origin`.
+Provide a token with Contents: write:
+
+```sh
+GH_TOKEN="$(gh auth token)" pnpm release
+```
+
+Do not leave unrelated tracked changes: bumpp commits every tracked dirty file
+(`all: true`).

--- a/bump.config.ts
+++ b/bump.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'bumpp'
+import { updateChangelog } from 'gh-changelogen'
+
+export default defineConfig({
+  files: ['package.json', 'jsr.json'],
+  all: true,
+  commit: 'release: v%s',
+  tag: true,
+  push: true,
+  execute: async operation => {
+    await updateChangelog({
+      repository: 'kazupon/args-tokens',
+      tagName: `v${operation.state.newVersion}`,
+      source: 'generated-notes',
+      targetCommitish: 'HEAD',
+      output: 'CHANGELOG.md'
+    })
+  }
+})

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "bench:vitest": "vitest bench --run",
     "build": "tsdown",
     "build:docs": "node scripts/generate-docs.mjs",
-    "changelog": "gh-changelogen --repo=kazupon/eslint-config",
     "dev": "pnpx @eslint/config-inspector --config eslint.config.ts",
     "dev:eslint": "pnpx @eslint/config-inspector --config eslint.config.ts",
     "fix": "pnpm --color run \"/^fix:/\"",
@@ -100,8 +99,9 @@
     "lint:oxlint": "oxlint --type-aware --type-check",
     "prepack": "pnpm build",
     "prepare": "git config --local core.hooksPath .githooks",
-    "release": "bumpp --commit \"release: v%s\" --all --push --tag",
-    "test": "vitest run --typecheck"
+    "release": "bumpp",
+    "test": "vitest run --typecheck",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@eslint/markdown": "^8.0.2",
@@ -119,7 +119,7 @@
     "eslint-plugin-oxlint": "^1.69.0",
     "eslint-plugin-regexp": "^3.1.0",
     "eslint-plugin-yml": "^3.4.0",
-    "gh-changelogen": "^0.2.8",
+    "gh-changelogen": "^2.0.2",
     "jsr": "^0.14.3",
     "jsr-exports-lint": "^0.4.2",
     "knip": "^6.16.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,8 +54,8 @@ importers:
         specifier: ^3.4.0
         version: 3.4.0(eslint@10.4.1(jiti@2.7.0))
       gh-changelogen:
-        specifier: ^0.2.8
-        version: 0.2.8
+        specifier: ^2.0.2
+        version: 2.0.2
       jsr:
         specifier: ^0.14.3
         version: 0.14.3
@@ -428,10 +428,6 @@ packages:
   '@eslint/plugin-kit@0.7.2':
     resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
-  '@fastify/busboy@2.1.1':
-    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
-    engines: {node: '>=14'}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -1862,9 +1858,6 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
-  destr@1.2.2:
-    resolution: {integrity: sha512-lrbCJwD9saUQrqUfXvl6qoM+QN3W7tLV5pAOs+OqOmopCCz/JkE05MHedJR1xfk4IAnZuJXPVuN5+7jNA2ZCiA==}
-
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
@@ -2101,9 +2094,9 @@ packages:
     resolution: {integrity: sha512-/6gFNr0N04nob252sTQxyFLi3eKFRqIg1I87YcqAMT1i6SQrSF6KujUEQrtrjMV0H/eejTCltLdDSTEMzHbnsQ==}
     engines: {node: '>=20.20.0'}
 
-  gh-changelogen@0.2.8:
-    resolution: {integrity: sha512-E9mRhhmpol2WkCqqljVhg+aUST0RE5WEDbh+oeF4MGIA1T+UvgYxv7sFQemnvY5EWj3pg2xz8cVzJX6gNvgHSw==}
-    engines: {node: '>= 14.18'}
+  gh-changelogen@2.0.2:
+    resolution: {integrity: sha512-4Qsyts73PSxeUNigYHa46TDAT/GDt5sW2B+C36wf0gUNGx8rjKuR21K9axE6nm1ZcRqSKfdpshsq4a9TMBNdpA==}
+    engines: {node: '>= 22'}
     hasBin: true
 
   github-slugger@2.0.0:
@@ -2116,6 +2109,10 @@ packages:
   globals@16.5.0:
     resolution: {integrity: sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==}
     engines: {node: '>=18'}
+
+  gunshi@0.37.1:
+    resolution: {integrity: sha512-C3t35z65PQpAHay/gzEu4J/7SNWXn2NhfC4RfZQPxyOqkPfDTizthxCPoSU48OazoVherCuCpFDKI1qcY425Gw==}
+    engines: {node: '>= 22'}
 
   hast-util-to-html@9.0.5:
     resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
@@ -2421,9 +2418,6 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  node-fetch-native@0.1.8:
-    resolution: {integrity: sha512-ZNaury9r0NxaT2oL65GvdGDy+5PlSaHTovT6JV5tOW07k1TQmgC0olZETa4C9KZg0+6zBr99ctTYa3Utqj9P/Q==}
-
   node-stream-zip@1.15.0:
     resolution: {integrity: sha512-LN4fydt9TqhZhThkZIVQnF9cwjU3qmUH9h78Mx/K7d3VvfRqqwthLwJEUOEL0QPZ0XQmNN7be5Ggit5+4dq3Bw==}
     engines: {node: '>=0.12.0'}
@@ -2433,10 +2427,6 @@ packages:
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
-
-  ohmyfetch@0.4.21:
-    resolution: {integrity: sha512-VG7f/JRvqvBOYvL0tHyEIEG7XHWm7OqIfAs6/HqwWwDfjiJ1g0huIpe5sFEmyb+7hpFa1EGNH2aERWR72tlClw==}
-    deprecated: Package renamed to https://github.com/unjs/ofetch
 
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
@@ -2617,23 +2607,18 @@ packages:
     resolution: {integrity: sha512-QNI2ChmuioGC1/xjyYwyZYADILWyW6AmS1UH6gDj/SFUUUS4MBAWs/7mxnkRPc/F4iHezDP+O8t0dO8WHiEOdg==}
     engines: {node: '>=6'}
 
-  semver@7.7.3:
-    resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
 
-  semver@7.8.0:
-    resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
+  semver@7.8.3:
+    resolution: {integrity: sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==}
     engines: {node: '>=10'}
     hasBin: true
 
-  semver@7.8.3:
-    resolution: {integrity: sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==}
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -2816,9 +2801,6 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  ufo@0.8.6:
-    resolution: {integrity: sha512-fk6CmUgwKCfX79EzcDQQpSCMxrHstvbLswFChHS0Vump+kFkw7nJBfTZoC1j0bOGoY9I7R3n2DGek5ajbcYnOw==}
-
   unbash@3.0.0:
     resolution: {integrity: sha512-FeFPZ/WFT0mbRCuydiZzpPFlrYN8ZUpphQKoq4EeElVIYjYyGzPMxQR/simUwCOJIyVhpFk4RbtyO7RuMpMnHA==}
     engines: {node: '>=14'}
@@ -2831,10 +2813,6 @@ packages:
 
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
-
-  undici@5.29.0:
-    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
-    engines: {node: '>=14.0'}
 
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
@@ -3013,16 +2991,8 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
-
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
-
-  zodiarg@0.2.1:
-    resolution: {integrity: sha512-Vbd8aW709iKX0XbMvjYkyjQYDBvWKedaUWNelcNeO1OxVYJ8jqUpj6lRBoO0PtN3b1DM6Ykz+hf9Y8e9pczmLQ==}
-    peerDependencies:
-      zod: 3.*
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -3275,8 +3245,6 @@ snapshots:
     dependencies:
       '@eslint/core': 1.2.1
       levn: 0.4.1
-
-  '@fastify/busboy@2.1.1': {}
 
   '@humanfs/core@0.19.1': {}
 
@@ -3946,7 +3914,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.61.0
       debug: 4.4.3
       minimatch: 10.2.5
-      semver: 7.8.0
+      semver: 7.8.3
       tinyglobby: 0.2.16
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
@@ -4258,8 +4226,6 @@ snapshots:
 
   dequal@2.0.3: {}
 
-  destr@1.2.2: {}
-
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
@@ -4553,12 +4519,10 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
-  gh-changelogen@0.2.8:
+  gh-changelogen@2.0.2:
     dependencies:
-      ohmyfetch: 0.4.21
-      semver: 7.7.3
-      zod: 3.25.76
-      zodiarg: 0.2.1(zod@3.25.76)
+      gunshi: 0.37.1
+      semver: 7.8.5
 
   github-slugger@2.0.0: {}
 
@@ -4567,6 +4531,8 @@ snapshots:
       is-glob: 4.0.3
 
   globals@16.5.0: {}
+
+  gunshi@0.37.1: {}
 
   hast-util-to-html@9.0.5:
     dependencies:
@@ -4634,7 +4600,7 @@ snapshots:
     dependencies:
       acorn: 8.16.0
       eslint-visitor-keys: 5.0.1
-      semver: 7.8.0
+      semver: 7.8.3
 
   jsonc-parser@3.3.1: {}
 
@@ -5078,20 +5044,11 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  node-fetch-native@0.1.8: {}
-
   node-stream-zip@1.15.0: {}
 
   object-deep-merge@2.0.1: {}
 
   obug@2.1.1: {}
-
-  ohmyfetch@0.4.21:
-    dependencies:
-      destr: 1.2.2
-      node-fetch-native: 0.1.8
-      ufo: 0.8.6
-      undici: 5.29.0
 
   onetime@7.0.0:
     dependencies:
@@ -5368,13 +5325,11 @@ snapshots:
 
   semiver@1.1.0: {}
 
-  semver@7.7.3: {}
-
   semver@7.7.4: {}
 
-  semver@7.8.0: {}
-
   semver@7.8.3: {}
+
+  semver@7.8.5: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -5534,8 +5489,6 @@ snapshots:
 
   typescript@6.0.3: {}
 
-  ufo@0.8.6: {}
-
   unbash@3.0.0: {}
 
   unconfig-core@7.5.0:
@@ -5552,10 +5505,6 @@ snapshots:
       unconfig-core: 7.5.0
 
   undici-types@7.24.6: {}
-
-  undici@5.29.0:
-    dependencies:
-      '@fastify/busboy': 2.1.1
 
   unist-util-is@6.0.1:
     dependencies:
@@ -5738,12 +5687,6 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zod@3.25.76: {}
-
   zod@4.4.3: {}
-
-  zodiarg@0.2.1(zod@3.25.76):
-    dependencies:
-      zod: 3.25.76
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
### Description

Generate `CHANGELOG.md` in the local `pnpm release` bumpp hook (gh-changelogen v2 `updateChangelog` with generated notes) so the version bump and changelog land in the same tagged commit.

The tag-push workflow no longer syncs or commits the changelog. After npm and JSR publish succeed, `release-notes` only creates the GitHub Release (`--verify-tag --generate-notes`, plus `--prerelease` for SemVer prerelease tags).

### Linked Issues

### Additional context

Same shape as [intlify/bundle-tools](https://github.com/intlify/bundle-tools). Release with:

```sh
GH_TOKEN="$(gh auth token)" pnpm release
```

`HEAD` must already be on `origin`. `all: true` commits every tracked dirty file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a streamlined release process that updates versions, generates changelogs, creates tags, and publishes releases.
  * Releases are now correctly identified as prereleases when applicable.
  * Added a standalone type-checking command.

* **Documentation**
  * Documented release prerequisites, authentication, and workflow behavior in the contributor guide.

* **Chores**
  * Improved handling of planning files and updated changelog tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->