### PR TITLE
fix(combinators): preserve inner modifiers in required/multiple types

### DIFF
--- a/src/combinators.test-d.ts
+++ b/src/combinators.test-d.ts
@@ -145,6 +145,31 @@ test('required + short composition type inference', () => {
   expectTypeOf<ExtractOptionValue<typeof composed>>().toEqualTypeOf<number>()
 })
 
+test('required + multiple composition type inference', () => {
+  const requiredMultiple = { items: required(multiple(string())) }
+  type RM = ArgValues<typeof requiredMultiple>['items']
+  expectTypeOf<RM>().toEqualTypeOf<string[]>()
+
+  const multipleRequired = { items: multiple(required(string())) }
+  type MR = ArgValues<typeof multipleRequired>['items']
+  expectTypeOf<MR>().toEqualTypeOf<string[]>()
+
+  const rm = required(multiple(string()))
+  const mr = multiple(required(string()))
+  expectTypeOf<ExtractOptionValue<typeof rm>>().toEqualTypeOf<string[]>()
+  expectTypeOf<ExtractOptionValue<typeof mr>>().toEqualTypeOf<string[]>()
+
+  const reqMultiInt = required(multiple(integer()))
+  type RMI = ArgValues<{ items: typeof reqMultiInt }>['items']
+  expectTypeOf<RMI>().toEqualTypeOf<number[]>()
+
+  const unreq = unrequired(multiple(required(string())))
+  type U = ArgValues<{ items: typeof unreq }>['items']
+  expectTypeOf<U>().toEqualTypeOf<string[] | undefined>()
+  expectTypeOf(unreq.required).toEqualTypeOf<false>()
+  expectTypeOf(unreq.multiple).toEqualTypeOf<true>()
+})
+
 test('ArgValues with combinators', () => {
   const args = {
     host: string(),

--- a/src/combinators.test.ts
+++ b/src/combinators.test.ts
@@ -633,6 +633,23 @@ describe('multiple combinator', () => {
     const { values } = resolveArgs({ tag: multiple(string()) }, tokens)
     expect(values.tag).toEqual(['foo', 'bar'])
   })
+
+  test('required(multiple) and multiple(required) keep both flags and resolve arrays', () => {
+    const requiredMultiple = required(multiple(string()))
+    const multipleRequired = multiple(required(string()))
+    expect(requiredMultiple.multiple).toBe(true)
+    expect(requiredMultiple.required).toBe(true)
+    expect(multipleRequired.multiple).toBe(true)
+    expect(multipleRequired.required).toBe(true)
+
+    const tokens = parseArgs(['--items', 'a', '--items', 'b'])
+    const a = resolveArgs({ items: requiredMultiple }, tokens)
+    const b = resolveArgs({ items: multipleRequired }, tokens)
+    expect(a.error).toBeUndefined()
+    expect(b.error).toBeUndefined()
+    expect(a.values.items).toEqual(['a', 'b'])
+    expect(b.values.items).toEqual(['a', 'b'])
+  })
 })
 
 describe('required combinator', () => {

--- a/src/combinators.ts
+++ b/src/combinators.ts
@@ -699,6 +699,14 @@ export function withDefault<T extends string | boolean | number>(
 }
 
 /**
+ * Overlay a flag onto a combinator schema without dropping other modifiers.
+ *
+ * Omits the flag keys from `S` first so optional `ArgSchema` fields
+ * (`multiple?: true`, `required?: boolean`) cannot stay as unions.
+ */
+type WithFlag<S, F> = Omit<S, keyof F> & F
+
+/**
  * Options for the {@link multiple} combinator.
  */
 type CombinatorMultiple = { multiple: true }
@@ -707,10 +715,11 @@ type CombinatorMultiple = { multiple: true }
  * Mark a combinator schema as accepting multiple values.
  *
  * The resolved value becomes an array. The original schema is not modified.
+ * Other modifiers on `schema` (for example {@link required}) are kept.
  *
- * @typeParam T - The schema's parsed type.
+ * @typeParam S - The input combinator schema.
  * @param schema - The base combinator schema.
- * @returns A new schema with `multiple: true`.
+ * @returns A copy of `schema` with `multiple: true`.
  *
  * @example
  * ```ts
@@ -723,7 +732,9 @@ type CombinatorMultiple = { multiple: true }
  * @experimental
  */
 // @__NO_SIDE_EFFECTS__
-export function multiple<T>(schema: CombinatorSchema<T>): CombinatorSchema<T> & CombinatorMultiple {
+export function multiple<S extends CombinatorSchema<unknown>>(
+  schema: S
+): WithFlag<S, CombinatorMultiple> {
   return {
     ...schema,
     multiple: true
@@ -739,11 +750,12 @@ type CombinatorRequired = { required: true }
  * Mark a combinator schema as required.
  *
  * The original schema is not modified.
+ * Other modifiers on `schema` (for example {@link multiple}) are kept.
  *
- * @typeParam T - The schema's parsed type.
+ * @typeParam S - The input combinator schema.
  *
  * @param schema - The base combinator schema.
- * @returns A new schema with `required: true`.
+ * @returns A copy of `schema` with `required: true`.
  *
  * @example
  * ```ts
@@ -755,7 +767,9 @@ type CombinatorRequired = { required: true }
  * @experimental
  */
 // @__NO_SIDE_EFFECTS__
-export function required<T>(schema: CombinatorSchema<T>): CombinatorSchema<T> & CombinatorRequired {
+export function required<S extends CombinatorSchema<unknown>>(
+  schema: S
+): WithFlag<S, CombinatorRequired> {
   return {
     ...schema,
     required: true


### PR DESCRIPTION
### Description

Fixes #579.

`required()` and `multiple()` kept both flags at runtime, but their return types rebuilt `CombinatorSchema<T>` and dropped the inner modifier. `ArgValues` then saw only the outer flag:

- `required(multiple(string()))` inferred `string`
- `multiple(required(string()))` inferred `string[] | undefined`

Both should be `string[]`.

This PR changes only the return types (same idea as `hidden` / `unrequired`): omit the flag key, then intersect the literal. Runtime spread is unchanged. `ArgValues` is not rewritten.

- `required(multiple(string()))` → `string[]`
- `multiple(required(string()))` → `string[]`
- `required(multiple(integer()))` → `number[]`
- `unrequired(multiple(required(string())))` → `string[] | undefined`

Not in this PR: `map` / `withDefault` / `short` / `describe` type preservation.

### Linked Issues

- #579

### Additional context

Local verification: `vp test` (257 tests, including combinator type tests), `vp check`, `vp pack`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved type inference when combining required and multiple options.
  - Ensured repeated command-line values are correctly parsed as arrays.
  - Preserved required and multiple option metadata when modifiers are combined.
  - Correctly supports optional repeated values, including `undefined` when an option is not provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->